### PR TITLE
feat: Add GlobalExceptionHandler to send custom responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 

--- a/src/main/java/com/carato/carato_backend/exceptions/GeneralException.java
+++ b/src/main/java/com/carato/carato_backend/exceptions/GeneralException.java
@@ -1,0 +1,19 @@
+package com.carato.carato_backend.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GeneralException extends RuntimeException {
+    final private HttpStatus httpStatus;
+
+    public GeneralException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public GeneralException(int statusCode, String message) {
+        super(message);
+        this.httpStatus = HttpStatus.valueOf(statusCode);
+    }
+}

--- a/src/main/java/com/carato/carato_backend/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/carato/carato_backend/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.carato.carato_backend.exceptions;
+
+import com.carato.carato_backend.responses.MessageResponse;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public MessageResponse<String> handleHttpMessageNotReadableException() {
+        return new MessageResponse<>("error", "Body not received or malformed");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public MessageResponse<String[]> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String[] errorMessages = ex.getBindingResult().getAllErrors().stream().map(DefaultMessageSourceResolvable::getDefaultMessage).toArray(String[]::new);
+
+        return new MessageResponse<>("error", errorMessages);
+    }
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<MessageResponse<String>> handleGeneralExceptions(GeneralException ex) {
+        HttpStatus httpStatus = ex.getHttpStatus();
+        String errorMessage = ex.getMessage();
+        MessageResponse<String> errorResponse = new MessageResponse<>("error", errorMessage);
+
+        return new ResponseEntity<>(errorResponse, httpStatus);
+    }
+}

--- a/src/main/java/com/carato/carato_backend/responses/MessageResponse.java
+++ b/src/main/java/com/carato/carato_backend/responses/MessageResponse.java
@@ -1,0 +1,11 @@
+package com.carato.carato_backend.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MessageResponse<T> {
+    private String status;
+    private T message;
+}


### PR DESCRIPTION
He creado la clase **GlobalExceptionHandler** para manejar futuros errores, mostrar un mensaje amigable con la estructura de **MessageResponse** y evitar los errores 500, hasta el momento se han manejado las siguientes excepciones:
- GlobalExceptionHandler: Por el momento solo maneja 3 posibles excepciones siendo:
  - HttpMessageNotReadableException: Esto ocurre cuando se intenta leer el body de una request y no es valido.
  - MethodArgumentNotValidException: Esto ocurre cuando se intenta validar los campos de una Request y no cumple con los requisitos. (requisitos tales como debe ser un valor numérico, no puede ser nulo, etc)
  - GeneralException: Excepcion creada por mi con el propósito de ofrecer una excepción genérica en la cual se pueda indicar el estado http y un mensaje de error.

Adicional he agregado la librería **spring-boot-starter-validation** que sera crucial a la hora de validar el cuerpo de las requests.